### PR TITLE
Improvement/fix of wake up by user button

### DIFF
--- a/src/boards/lilygo_nrf52840/board.h
+++ b/src/boards/lilygo_nrf52840/board.h
@@ -39,8 +39,8 @@
 /* BUTTON
  *------------------------------------------------------------------*/
 #define BUTTONS_NUMBER        2
-#define BUTTON_1              _PINNUM(0, 18)
-#define BUTTON_2              _PINNUM(1, 10)
+#define BUTTON_DFU            _PINNUM(1, 10)
+#define BUTTON_FRESET         _PINNUM(0, 18)
 #define BUTTON_PULL           NRF_GPIO_PIN_PULLUP
 
 //--------------------------------------------------------------------+

--- a/src/main.c
+++ b/src/main.c
@@ -109,6 +109,7 @@ void usb_teardown(void);
 #define DFU_MAGIC_OTA_RESET             0xA8
 #define DFU_MAGIC_SERIAL_ONLY_RESET     0x4e
 #define DFU_MAGIC_UF2_RESET             0x57
+#define DFU_MAGIC_SKIP                  0x6d
 
 #define DFU_DBL_RESET_MAGIC             0x5A1AD5      // SALADS
 #define DFU_DBL_RESET_APP               0x4ee5677e
@@ -175,8 +176,10 @@ int main(void)
   bool dfu_start = _ota_dfu || serial_only_dfu || (NRF_POWER->GPREGRET == DFU_MAGIC_UF2_RESET) ||
                     (((*dbl_reset_mem) == DFU_DBL_RESET_MAGIC) && (NRF_POWER->RESETREAS & POWER_RESETREAS_RESETPIN_Msk));
 
+  bool dfu_skip = (NRF_POWER->GPREGRET == DFU_MAGIC_SKIP);
+
   // Clear GPREGRET if it is our values
-  if (dfu_start) NRF_POWER->GPREGRET = 0;
+  if (dfu_start || dfu_skip) NRF_POWER->GPREGRET = 0;
 
   // Save bootloader version to pre-defined register, retrieved by application
   // TODO move to CF2
@@ -200,7 +203,7 @@ int main(void)
 
   /*------------- Determine DFU mode (Serial, OTA, FRESET or normal) -------------*/
   // DFU button pressed
-  dfu_start  = dfu_start || button_pressed(BUTTON_DFU);
+  dfu_start  = dfu_start || (button_pressed(BUTTON_DFU) && !dfu_skip);
 
   // DFU + FRESET are pressed --> OTA
   _ota_dfu = _ota_dfu  || ( button_pressed(BUTTON_DFU) && button_pressed(BUTTON_FRESET) ) ;


### PR DESCRIPTION
When an app is doing wake up by releasing the USER_BTN - the nRF bootloader enters into DFU mode (because of BUTTON_DFU is active). This is not a behaviour that we are  looking for.

This PR gives an option to bypass the bootloader's DFU mode by use of the MCU retention register.

This is an example of the feature usage in an Arduino sketch:

```
#define DFU_MAGIC_SKIP        0x6d

NRF_POWER->GPREGRET = DFU_MAGIC_SKIP;
pinMode(SOC_GPIO_PIN_BUTTON, INPUT_PULLUP_SENSE /* INPUT_SENSE_LOW */);

uint8_t sd_en;
(void) sd_softdevice_is_enabled(&sd_en);

if ( sd_en ) {
  sd_power_system_off();
} else {
  NRF_POWER->SYSTEMOFF = 1;
}
```
