### PR TITLE
give certain time for RESET button capacitor to charge up

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -201,6 +201,9 @@ int main(void)
     led_state(STATE_WRITING_FINISHED);
   }
 
+  /* give certain time for RESET button capacitor to charge up */
+  NRFX_DELAY_MS(200);
+
   /*------------- Determine DFU mode (Serial, OTA, FRESET or normal) -------------*/
   // DFU button pressed
   dfu_start  = dfu_start || (button_pressed(BUTTON_DFU) && !dfu_skip);


### PR DESCRIPTION
When the board is connected to a power source - it typically gets stuck in the bootloader code.
The following manual restart cycle with RESET push button does always help.
Reason for this every first boot failure is likely insufficent maximum current that board power curcuits are able to produce in order to (peak) charge all the decoupling capacitors and every of the ICs warmup.

This PR is actually a kind of workaround. It is intended to delay the bootloader buttons sensing procedure until the board gets enough power to become saturated.