### PR TITLE
make use of the touch button to activate BLE OTA feature

### DIFF
--- a/src/boards/boards.c
+++ b/src/boards/boards.c
@@ -82,10 +82,10 @@ void board_init(void)
   neopixel_init();
 #endif
 
-#if ENABLE_DCDC_0 == 1
+#if defined(ENABLE_DCDC_0) && ENABLE_DCDC_0 == 1
   NRF_POWER->DCDCEN0 = 1;
 #endif
-#if ENABLE_DCDC_1 == 1
+#if defined(ENABLE_DCDC_1) && ENABLE_DCDC_1 == 1
   NRF_POWER->DCDCEN = 1;
 #endif
 

--- a/src/boards/lilygo_nrf52840/board.h
+++ b/src/boards/lilygo_nrf52840/board.h
@@ -45,8 +45,8 @@
 /* BUTTON
  *------------------------------------------------------------------*/
 #define BUTTONS_NUMBER        2
-#define BUTTON_DFU            _PINNUM(1, 10)
-#define BUTTON_FRESET         _PINNUM(0, 18)
+#define BUTTON_DFU            _PINNUM(1, 10)    /* USB UF2 and CDC */
+#define BUTTON_FRESET         _PINNUM(0, 11)    /* BLE OTA         */
 #define BUTTON_PULL           NRF_GPIO_PIN_PULLUP
 
 //--------------------------------------------------------------------+


### PR DESCRIPTION
Current FRESET (Factory Reset) button assignment to physical RESET button (P0.18) has little or no use.
As far as I understand, they typically assign FRST is physical RESET on those boards that have only one user button available. But the LilyGO board has two user buttons.

This PR gives an option to use BLE OTA firmware upgrade feature provided by the bootloader.
FRESET is now assigned to the touch button (P0.11)

This PR does not affect standard single and double RESET button click function supported by the bootloader.

The logic to activate BLE OTA is this one:
https://github.com/adafruit/Adafruit_nRF52_Bootloader#how-to-use

- `DFU = LOW` and `FRST = LOW`: Enter bootloader with OTA, to upgrade with a mobile application such as Nordic nrfConnect/Toolbox

The modified bootloader works fine to me together with [Bluefruit Connect](https://play.google.com/store/apps/details?id=com.adafruit.bluefruit.le.connect) for Android.

![image](https://user-images.githubusercontent.com/5849637/108682012-d5a8ee80-7500-11eb-8a31-ac5fa8286ba9.png)

![image](https://user-images.githubusercontent.com/5849637/108682088-f113f980-7500-11eb-81e4-96993103e765.png)

<br>
<br>

And with [nRF Connect for Mobile](https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp) as well:

<br>
<br>

![image](https://user-images.githubusercontent.com/5849637/108685344-17d42f00-7505-11eb-8a2b-b24778a5ff36.png)

<br>
<br>

![image](https://user-images.githubusercontent.com/5849637/108684886-82389f80-7504-11eb-86fb-ebf7cf11310a.png)

<br>

![image](https://user-images.githubusercontent.com/5849637/108685135-d3e12a00-7504-11eb-9225-7209ae53cd1f.png)


